### PR TITLE
All rv32ui-p-* tests passed

### DIFF
--- a/rv32_tests.sh
+++ b/rv32_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+test_dir=/opt/riscv32/share/riscv-tests/isa/
+test_kind="rv32ui-p"
+
+for test_name in `ls $test_dir | grep $test_kind | grep -v .dump`; do
+    cargo r $test_dir$test_name > /dev/null 2>&1;
+    result=$?;
+
+	ESC=$(printf '\033');
+	if [ $result = 1 ]; then
+		echo "$test_name ${ESC}[32;1m ... passed ${ESC}[m"
+	else
+		echo "$test_name ${ESC}[31;1m ... failed ${ESC}[m"
+	fi
+
+done;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -39,7 +39,7 @@ impl CPU {
         self.pc = (self.pc as i32 + addval) as usize;
     }
 
-    pub fn update_pc(&mut self, newval: u32) {
+    pub fn update_pc(&mut self, newval: i32) {
         self.pc = newval as usize;
     }
 

--- a/src/cpu/decode.rs
+++ b/src/cpu/decode.rs
@@ -45,6 +45,8 @@ mod tests {
                 OP_AUIPC, Some(5), None, None, Some(0));
         test_32(0b11111111100111111111000001101111,
                 OP_JAL, Some(0), None, None, Some(-8));
+        test_32(0b11111110001000001000111010100011,
+                OP_SB, None, Some(1), Some(2), Some(-3));
         test_32(0b11101110110000101000001010010011,
                 OP_ADDI, Some(5), Some(5), None, Some(-276));
         test_32(0b00000000000000000000000001110011,

--- a/src/cpu/decode/mmap_parse_32.rs
+++ b/src/cpu/decode/mmap_parse_32.rs
@@ -256,7 +256,7 @@ impl Decode for u32 {
             self.to_signed_nbit(imm32, 12)
         };
         let S_type = | | {
-            let imm32 = ((((inst >> 25) & 0x1F) << 5) | ((inst >> 7) & 0x1F)) as i32;
+            let imm32 = ((((inst >> 25) & 0x7F) << 5) | ((inst >> 7) & 0x1F)) as i32;
             self.to_signed_nbit(imm32, 12)
         };
         let B_type = | | {

--- a/src/cpu/decode/mmap_parse_32.rs
+++ b/src/cpu/decode/mmap_parse_32.rs
@@ -137,6 +137,7 @@ impl Decode for u32 {
             OpecodeKind::OP_ANDI	=> Some(rd),
             OpecodeKind::OP_SLLI	=> Some(rd),
             OpecodeKind::OP_SRLI	=> Some(rd),
+            OpecodeKind::OP_SRAI	=> Some(rd),
             OpecodeKind::OP_ADD		=> Some(rd),
             OpecodeKind::OP_SUB		=> Some(rd),
             OpecodeKind::OP_SLL		=> Some(rd),
@@ -186,6 +187,7 @@ impl Decode for u32 {
             OpecodeKind::OP_ANDI	=> Some(rs1),
             OpecodeKind::OP_SLLI	=> Some(rs1),
             OpecodeKind::OP_SRLI	=> Some(rs1),
+            OpecodeKind::OP_SRAI	=> Some(rs1),
             OpecodeKind::OP_ADD		=> Some(rs1),
             OpecodeKind::OP_SUB		=> Some(rs1),
             OpecodeKind::OP_SLL		=> Some(rs1),
@@ -297,6 +299,7 @@ impl Decode for u32 {
             OpecodeKind::OP_ANDI	=> Some(I_type()),
             OpecodeKind::OP_SLLI	=> Some(I_type()),
             OpecodeKind::OP_SRLI	=> Some(I_type()),
+            OpecodeKind::OP_SRAI	=> Some(I_type()),
             _ => None,
         }
     }

--- a/src/cpu/execution.rs
+++ b/src/cpu/execution.rs
@@ -23,6 +23,5 @@ impl Execution for Instruction {
         }
 
         cpu.show_regs();
-        if cpu.pc > 0x142c { panic!("out of range: 0x{:x}", cpu.pc); }
     }
 }

--- a/src/cpu/execution/exe_inst_32.rs
+++ b/src/cpu/execution/exe_inst_32.rs
@@ -21,8 +21,10 @@ pub fn exe_inst(inst: &Instruction, cpu: &mut CPU) {
             cpu.add2pc(inst.imm.unwrap());
         },
         OP_JALR => {
-            cpu.update_pc(cpu.read_reg(inst.rs1)  + inst.imm.unwrap());
-            cpu.write_reg(inst.rd, (cpu.pc + INST_SIZE) as i32); 
+            let next_pc = cpu.pc + INST_SIZE;
+            // setting the least-significant bit of the result to zero  vvvvvv
+            cpu.update_pc((cpu.read_reg(inst.rs1)  + inst.imm.unwrap()) & !0x1);
+            cpu.write_reg(inst.rd, next_pc as i32); 
         },
         OP_BEQ => {
             if cpu.read_reg(inst.rs1) == cpu.read_reg(inst.rs2) {

--- a/src/cpu/execution/exe_inst_32.rs
+++ b/src/cpu/execution/exe_inst_32.rs
@@ -21,8 +21,8 @@ pub fn exe_inst(inst: &Instruction, cpu: &mut CPU) {
             cpu.add2pc(inst.imm.unwrap());
         },
         OP_JALR => {
+            cpu.update_pc(cpu.read_reg(inst.rs1)  + inst.imm.unwrap());
             cpu.write_reg(inst.rd, (cpu.pc + INST_SIZE) as i32); 
-            cpu.add2pc(cpu.read_reg(inst.rs1)  + inst.imm.unwrap());
         },
         OP_BEQ => {
             if cpu.read_reg(inst.rs1) == cpu.read_reg(inst.rs2) {
@@ -170,7 +170,7 @@ pub fn exe_inst(inst: &Instruction, cpu: &mut CPU) {
             cpu.write_csr(CSRname::mepc.wrap(), cpu.pc as i32);
             cpu.bitclr_csr(CSRname::mstatus.wrap(), 0x3 << 11);
             cpu.priv_lv = PrivilegedLevel::Machine;
-            cpu.update_pc(cpu.read_csr(CSRname::mtvec.wrap()));
+            cpu.update_pc(cpu.read_csr(CSRname::mtvec.wrap()) as i32);
         },
         OP_EBREAK => {
             panic!("not yet implemented: OP_EBREAK");
@@ -200,7 +200,7 @@ pub fn exe_inst(inst: &Instruction, cpu: &mut CPU) {
             cpu.bitclr_csr(inst.rs2, inst.rs1.unwrap() as i32);
         },
         OP_MRET => {
-            cpu.update_pc(cpu.read_csr(CSRname::mepc.wrap()));
+            cpu.update_pc(cpu.read_csr(CSRname::mepc.wrap()) as i32);
             cpu.priv_lv = match cpu.read_csr_mstatus(Mstatus::MPP) {
                 0b00 => PrivilegedLevel::User,
                 0b01 => PrivilegedLevel::Supervisor,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl Simulator {
 
             // debug code
             if break_point.unwrap_or(usize::MAX) == self.cpu.pc {
-                break;
+                std::process::exit(self.cpu.read_reg(Some(3)));
             }
         }
     }


### PR DESCRIPTION
Add a script rv32_tests and all rv32ui-p-* tests passed.

- [x] rv32ui-p-add
- [x] rv32ui-p-addi
- [x] rv32ui-p-and
- [x] rv32ui-p-andi
- [x] rv32ui-p-auipc
- [x] rv32ui-p-beq
- [x] rv32ui-p-bge
- [x] rv32ui-p-bgeu
- [x] rv32ui-p-blt
- [x] rv32ui-p-bltu
- [x] rv32ui-p-bne
- [x] rv32ui-p-fence_i
- [x] rv32ui-p-jal
- [x] rv32ui-p-jalr
- [x] rv32ui-p-lb
- [x] rv32ui-p-lbu
- [x] rv32ui-p-lh
- [x] rv32ui-p-lhu
- [x] rv32ui-p-lui
- [x] rv32ui-p-lw
- [x] rv32ui-p-or
- [x] rv32ui-p-ori
- [x] rv32ui-p-sb
- [x] rv32ui-p-sh
- [x] rv32ui-p-simple
- [x] rv32ui-p-sll
- [x] rv32ui-p-slli
- [x] rv32ui-p-slt
- [x] rv32ui-p-slti
- [x] rv32ui-p-sltiu
- [x] rv32ui-p-sltu
- [x] rv32ui-p-sra
- [x] rv32ui-p-srai
- [x] rv32ui-p-srl
- [x] rv32ui-p-srli
- [x] rv32ui-p-sub
- [x] rv32ui-p-sw
- [x] rv32ui-p-xor
- [x] rv32ui-p-xori